### PR TITLE
ROCANA-3431: Create a crunch release script

### DIFF
--- a/crunch-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/crunch-archetype/src/main/resources/archetype-resources/pom.xml
@@ -136,4 +136,39 @@
     <maven>2.2.1</maven>
   </prerequisites>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>HDPReleases</id>
+      <name>HDP Releases</name>
+      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <layout>default</layout>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>HDPJettyReleases</id>
+      <name>HDP Jetty Releases</name>
+      <url>http://repo.hortonworks.com/content/repositories/jetty-hadoop/</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,10 +102,10 @@ under the License.
   </properties>
 
   <scm>
-    <url>https://git-wip-us.apache.org/repos/asf?p=crunch.git</url>
-    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/crunch.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/crunch.git</developerConnection>
-    <tag>apache-crunch-0.13.0</tag>
+    <url>https://github.com/scalingdata/crunch</url>
+    <connection>scm:git:git@github.com:scalingdata/crunch.git</connection>
+    <developerConnection>scm:git:git@github.com:scalingdata/crunch.git</developerConnection>
+    <tag>0.13.0-hdp2.3.0-rocana</tag>
   </scm>
 
   <issueManagement>
@@ -794,6 +794,19 @@ under the License.
       </plugins>
     </pluginManagement>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>com.rocana.releases</id>
+      <name>Rocana Release Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>com.rocana.snapshots</id>
+      <name>Rocana Snapshots Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <repositories>
     <repository>

--- a/rocana-release.sh
+++ b/rocana-release.sh
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#!/bin/bash
+set -x
+
+MVN=$(type -p mvn)
+MVN_FLAGS="-B"
+
+if [ -z "${CRUNCH_RELEASE_VERSION}" ] || [ -z "${CRUNCH_DEVELOPMENT_VERSION}" ]; then
+  echo "You must set CRUNCH_RELEASE_VERSION and CRUNCH_DEVELOPMENT_VERSION before running this script."
+  exit 1
+fi
+
+if [ -n "${WORKSPACE}" ]; then
+  MVN_FLAGS="${MVN_FLAGS} -f ${WORKSPACE}/pom.xml"
+  MVN_FLAGS="${MVN_FLAGS} -Dmaven.repo.local=${WORKSPACE}/.repository"
+fi
+
+# Set the version to the next release
+${MVN} ${MVN_FLAGS} \
+  versions:set \
+    -DnewVersion=${CRUNCH_RELEASE_VERSION} \
+    -DgenerateBackupPoms=false
+
+# Commit and push the version number update
+${MVN} ${MVN_FLAGS} \
+  scm:add \
+    -Dincludes=**/pom.xml \
+    -Dexcludes=**/target/**/pom.xml \
+  scm:checkin \
+    -Dmessage="ROCANA-BUILD: Preparing for release ${CRUNCH_RELEASE_VERSION}"
+
+# Package the release and run tests
+${MVN} ${MVN_FLAGS} \
+  clean \
+  package
+
+# Deploy the release to the maven repo and tag the release in git
+${MVN} ${MVN_FLAGS} \
+  deploy \
+    -DskipTests \
+  scm:tag \
+    -Dtag=release-${CRUNCH_RELEASE_VERSION}
+
+# Set the version to the next development version
+${MVN} ${MVN_FLAGS} \
+  versions:set \
+    -DnewVersion=${CRUNCH_DEVELOPMENT_VERSION} \
+    -DgenerateBackupPoms=false
+
+# Commit and push the version number update
+${MVN} ${MVN_FLAGS} \
+  scm:add \
+    -Dincludes=**/pom.xml \
+    -Dexcludes=**/target/**/pom.xml \
+  scm:checkin \
+    -Dmessage="ROCANA-BUILD: Preparing for ${CRUNCH_DEVELOPMENT_VERSION} development"


### PR DESCRIPTION
- Add distributionManagement so that deploy target works
- Add HDP repositories to archetype pom file for tests to pass under
    certain mavent targets.
- Updated SCM connection to point to Rocana github.
- Added release script
