### PR TITLE
ROCANA-3475: Fix unstable crunch tests

### DIFF
--- a/crunch-core/src/main/java/org/apache/crunch/types/avro/AvroOutputFormat.java
+++ b/crunch-core/src/main/java/org/apache/crunch/types/avro/AvroOutputFormat.java
@@ -45,7 +45,7 @@ public class AvroOutputFormat<T> extends FileOutputFormat<AvroWrapper<T>, NullWr
 
     if (org.apache.hadoop.mapred.FileOutputFormat.getCompressOutput(jc)) {
       int level = conf.getInt(org.apache.avro.mapred.AvroOutputFormat.DEFLATE_LEVEL_KEY,
-          org.apache.avro.mapred.AvroOutputFormat.DEFAULT_DEFLATE_LEVEL);
+          org.apache.avro.file.CodecFactory.DEFAULT_DEFLATE_LEVEL);
       String codecName = conf.get(AvroJob.OUTPUT_CODEC,
           org.apache.avro.file.DataFileConstants.DEFLATE_CODEC);
       CodecFactory codec = codecName.equals(org.apache.avro.file.DataFileConstants.DEFLATE_CODEC)

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ under the License.
     <commons-codec.version>1.4</commons-codec.version>
     <commons-httpclient.version>3.0.1</commons-httpclient.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <avro.version>1.7.5</avro.version>
+    <avro.version>1.7.6</avro.version>
     <hive.version>1.2.1.2.3.0.0-2557</hive.version>
     <parquet.version>1.6.0</parquet.version>
     <javassist.version>3.16.1-GA</javassist.version>


### PR DESCRIPTION
- This required upgrading Avro to 1.7.6
